### PR TITLE
(2) fix(1500): Add a request to delete zip files

### DIFF
--- a/lib/helper/request-store.js
+++ b/lib/helper/request-store.js
@@ -66,7 +66,27 @@ const putArtifact = async (buildId, token, fileName, file) => {
     }
 };
 
+const deleteZip = async (buildId, token) => {
+    const options = {
+        url: `${baseUrl}/builds/${buildId}/ARTIFACTS/${ZIP_FILE}`,
+        method: 'DELETE',
+        headers: {
+            Authorization: token
+        },
+        retry: {
+            limit: RETRY_LIMIT
+        }
+    };
+
+    try {
+        return request(options);
+    } catch (err) {
+        throw new Error(err.response.body.toString());
+    }
+};
+
 module.exports = {
     getZipArtifact,
-    putArtifact
+    putArtifact,
+    deleteZip
 };

--- a/lib/helper/request-store.js
+++ b/lib/helper/request-store.js
@@ -30,7 +30,7 @@ const getZipArtifact = async (buildId, token) => {
     };
 
     try {
-        return request(options);
+        return await request(options);
     } catch (err) {
         throw new Error(err.response.body.toString());
     }
@@ -60,7 +60,7 @@ const putArtifact = async (buildId, token, fileName, file) => {
     };
 
     try {
-        return request(options);
+        return await request(options);
     } catch (err) {
         throw new Error(err.response.body.toString());
     }
@@ -79,7 +79,7 @@ const deleteZip = async (buildId, token) => {
     };
 
     try {
-        return request(options);
+        return await request(options);
     } catch (err) {
         throw new Error(err.response.body);
     }

--- a/lib/helper/request-store.js
+++ b/lib/helper/request-store.js
@@ -66,7 +66,7 @@ const putArtifact = async (buildId, token, fileName, file) => {
     }
 };
 
-const deleteZip = async (buildId, token) => {
+const deleteZipArtifact = async (buildId, token) => {
     const options = {
         url: `${baseUrl}/builds/${buildId}/ARTIFACTS/${ZIP_FILE}`,
         method: 'DELETE',
@@ -88,5 +88,5 @@ const deleteZip = async (buildId, token) => {
 module.exports = {
     getZipArtifact,
     putArtifact,
-    deleteZip
+    deleteZipArtifact
 };

--- a/lib/helper/request-store.js
+++ b/lib/helper/request-store.js
@@ -81,7 +81,7 @@ const deleteZip = async (buildId, token) => {
     try {
         return request(options);
     } catch (err) {
-        throw new Error(err.response.body.toString());
+        throw new Error(err.response.body);
     }
 };
 

--- a/lib/helper/request-store.js
+++ b/lib/helper/request-store.js
@@ -81,7 +81,7 @@ const deleteZipArtifact = async (buildId, token) => {
     try {
         return await request(options);
     } catch (err) {
-        throw new Error(err.response.body);
+        throw new Error(err.response.body.toString());
     }
 };
 

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -48,7 +48,6 @@ async function unzip(config) {
         await store.deleteZip(config.buildId, config.token);
     } catch (err) {
         logger.error(err.message);
-        throw err;
     }
 
     logger.info(`Job:unzip finished. buildId: ${config.buildId}`);

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -45,7 +45,7 @@ async function unzip(config) {
     }
 
     try {
-        await store.deleteZip(config.buildId, config.token);
+        await store.deleteZipArtifact(config.buildId, config.token);
     } catch (err) {
         logger.error(err.message);
     }

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -44,6 +44,13 @@ async function unzip(config) {
         throw err;
     }
 
+    try {
+        await store.deleteZip(config.buildId, config.token);
+    } catch (err) {
+        logger.error(err.message);
+        throw err;
+    }
+
     logger.info(`Job:unzip finished. buildId: ${config.buildId}`);
 }
 

--- a/test/lib/helper/request-store.test.js
+++ b/test/lib/helper/request-store.test.js
@@ -159,7 +159,7 @@ describe('Request to Store Unit Test', () => {
         });
     });
 
-    describe('deleteZip function', () => {
+    describe('deleteZipArtifact function', () => {
         it('can delete zip file to Store', async () => {
             mockRequest
                 .withArgs({
@@ -175,7 +175,7 @@ describe('Request to Store Unit Test', () => {
                 .resolves({ statusCode: 204 });
 
             try {
-                const result = await store.deleteZip(buildId, token);
+                const result = await store.deleteZipArtifact(buildId, token);
 
                 assert.equal(result.statusCode, 204);
             } catch (err) {
@@ -200,7 +200,7 @@ describe('Request to Store Unit Test', () => {
                 .throws(errObj);
 
             try {
-                await store.deleteZip(buildId, token);
+                await store.deleteZipArtifact(buildId, token);
             } catch (err) {
                 assert.equal(err.message, 'Some Error!');
             }

--- a/test/lib/helper/request-store.test.js
+++ b/test/lib/helper/request-store.test.js
@@ -200,7 +200,7 @@ describe('Request to Store Unit Test', () => {
                 .throws(errObj);
 
             try {
-                await store.putArtifact(buildId, token);
+                await store.deleteZip(buildId, token);
             } catch (err) {
                 assert.equal(err.message, 'Some Error!');
             }

--- a/test/lib/helper/request-store.test.js
+++ b/test/lib/helper/request-store.test.js
@@ -158,4 +158,52 @@ describe('Request to Store Unit Test', () => {
             }
         });
     });
+
+    describe('deleteZip function', () => {
+        it('can delete zip file to Store', async () => {
+            mockRequest
+                .withArgs({
+                    url: 'https://test-store.screwdriver.cd/v1/builds/1234/ARTIFACTS/SD_ARTIFACT.zip',
+                    method: 'DELETE',
+                    headers: {
+                        Authorization: 'dummytoken'
+                    },
+                    retry: {
+                        limit: 5
+                    }
+                })
+                .resolves({ statusCode: 204 });
+
+            try {
+                const result = await store.deleteZip(buildId, token);
+
+                assert.equal(result.statusCode, 204);
+            } catch (err) {
+                assert.fail('Never reaches here');
+            }
+        });
+
+        it('throws exception when some error occurs', async () => {
+            const errObj = { response: { body: Buffer.from('Some Error!') } };
+
+            mockRequest
+                .withArgs({
+                    url: 'https://test-store.screwdriver.cd/v1/builds/1234/ARTIFACTS/SD_ARTIFACT.zip',
+                    method: 'DELETE',
+                    headers: {
+                        Authorization: 'dummytoken'
+                    },
+                    retry: {
+                        limit: 5
+                    }
+                })
+                .throws(errObj);
+
+            try {
+                await store.putArtifact(buildId, token);
+            } catch (err) {
+                assert.equal(err.message, 'Some Error!');
+            }
+        });
+    });
 });

--- a/test/lib/jobs.test.js
+++ b/test/lib/jobs.test.js
@@ -29,7 +29,8 @@ describe('Jobs Unit Test', () => {
     beforeEach(() => {
         mockStore = {
             getZipArtifact: sinon.stub(),
-            putArtifact: sinon.stub()
+            putArtifact: sinon.stub(),
+            deleteZip: sinon.stub()
         };
         mockery.registerMock('./helper/request-store', mockStore);
 
@@ -62,6 +63,7 @@ describe('Jobs Unit Test', () => {
             mockStore.putArtifact
                 .withArgs(unzipConfig.buildId, unzipConfig.token, fileName2, file2)
                 .resolves({ statusCode: 202 });
+            mockStore.deleteZip.withArgs(unzipConfig.buildId, unzipConfig.token).resolves({ statusCode: 202 });
 
             assert.equal(await jobs.start.perform(unzipConfig), null);
         });
@@ -97,6 +99,30 @@ describe('Jobs Unit Test', () => {
                 assert.fail('Never reaches here');
             } catch (err) {
                 assert.equal(err.message, 'failed to put an artifact to Store');
+            }
+        });
+
+        it('raises an error when it failed to delete ZIP artifacts', async () => {
+            const testZip = new AdmZip();
+
+            testZip.addFile(fileName1, file1);
+            testZip.addFile(fileName2, file2);
+
+            mockStore.getZipArtifact
+                .withArgs(unzipConfig.buildId, unzipConfig.token)
+                .resolves({ body: testZip.toBuffer() });
+            mockStore.putArtifact
+                .withArgs(unzipConfig.buildId, unzipConfig.token, fileName2, file2)
+                .resolves({ statusCode: 202 });
+            mockStore.deleteZip
+                .withArgs(unzipConfig.buildId, unzipConfig.token)
+                .throws(new Error('failed to delete an artifact to Store'));
+
+            try {
+                await jobs.start.perform(unzipConfig);
+                assert.fail('Never reaches here');
+            } catch (err) {
+                assert.equal(err.message, 'failed to delete an artifact to Store');
             }
         });
     });

--- a/test/lib/jobs.test.js
+++ b/test/lib/jobs.test.js
@@ -102,7 +102,9 @@ describe('Jobs Unit Test', () => {
             }
         });
 
-        it('raises an error when it failed to delete ZIP artifacts', async () => {
+        // If the deletion of the zip fails, the job itself will not fail.
+        // The message of the zip deletion failure will be written in the log.
+        it('not raises an error when it failed to delete ZIP artifacts', async () => {
             const testZip = new AdmZip();
 
             testZip.addFile(fileName1, file1);
@@ -120,9 +122,8 @@ describe('Jobs Unit Test', () => {
 
             try {
                 await jobs.start.perform(unzipConfig);
-                assert.fail('Never reaches here');
             } catch (err) {
-                assert.equal(err.message, 'failed to delete an artifact to Store');
+                assert.fail(err.message, 'Never reaches here');
             }
         });
     });

--- a/test/lib/jobs.test.js
+++ b/test/lib/jobs.test.js
@@ -30,7 +30,7 @@ describe('Jobs Unit Test', () => {
         mockStore = {
             getZipArtifact: sinon.stub(),
             putArtifact: sinon.stub(),
-            deleteZip: sinon.stub()
+            deleteZipArtifact: sinon.stub()
         };
         mockery.registerMock('./helper/request-store', mockStore);
 
@@ -63,7 +63,7 @@ describe('Jobs Unit Test', () => {
             mockStore.putArtifact
                 .withArgs(unzipConfig.buildId, unzipConfig.token, fileName2, file2)
                 .resolves({ statusCode: 202 });
-            mockStore.deleteZip.withArgs(unzipConfig.buildId, unzipConfig.token).resolves({ statusCode: 202 });
+            mockStore.deleteZipArtifact.withArgs(unzipConfig.buildId, unzipConfig.token).resolves({ statusCode: 202 });
 
             assert.equal(await jobs.start.perform(unzipConfig), null);
         });
@@ -116,7 +116,7 @@ describe('Jobs Unit Test', () => {
             mockStore.putArtifact
                 .withArgs(unzipConfig.buildId, unzipConfig.token, fileName2, file2)
                 .resolves({ statusCode: 202 });
-            mockStore.deleteZip
+            mockStore.deleteZipArtifact
                 .withArgs(unzipConfig.buildId, unzipConfig.token)
                 .throws(new Error('failed to delete an artifact to Store'));
 


### PR DESCRIPTION
## Context
To implement SD_ZIP_ARTIFACTS feature by [new design](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md)

Make sure to throw a request to the endpoint for deleting the zip file, which we will add in this [PR](https://github.com/screwdriver-cd/store/pull/131).
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Fix to send a request to delete the zip file to the store after the zip file is successfully extracted.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
[design doc](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md#sd-api-api)
[issue](https://github.com/screwdriver-cd/screwdriver/issues/1500)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
