### PR TITLE
fix: Add api endpoint for health check, and rename unzip-worker to unzip-sevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Screwdriver Artifacts Unzip Worker
+# Screwdriver Artifacts Unzip Service
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
 > A worker implementation that consumes jobs from Resque.
@@ -6,7 +6,7 @@
 ## Usage
 
 ```bash
-npm install screwdriver-artifacts-unzip-worker
+npm install screwdriver-artifacts-unzip-service
 ```
 
 ## Testing

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -14,7 +14,7 @@ queue:
     database: REDIS_DB_NUMBER
   prefix: REDIS_QUEUE_PREFIX
 
-unzip-worker:
+unzip-service:
   # https://github.com/taskrabbit/node-resque#multiworker-options
   # minimum number of workers to spawn
   minTaskProcessors: WORKER_MIN_TASK_PROCESSORS

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -24,3 +24,11 @@ unzip-service:
   checkTimeout: WORKER_CHECK_TIMEOUT
   # how long the event loop has to be delayed before considering it blocked (ms)
   maxEventLoopDelay: WORKER_MAX_EVENT_LOOP_DELAY
+
+httpd:
+  # Port to listen on
+  port: PORT
+  # Host to listen on (set to 0.0.0.0 to accept all connections)
+  host: HOST
+  # Externally routable URI (usually your load balancer or CNAME)
+  uri: URI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -22,3 +22,11 @@ unzip-service:
   checkTimeout: 1000
   # how long the event loop has to be delayed before considering it blocked (ms)
   maxEventLoopDelay: 10
+
+httpd:
+  # Port to listen on
+  port: 80
+  # Host to listen on (set to localhost to only accept connections from this machine)
+  host: 0.0.0.0
+  # Externally routable URI (usually your load balancer or CNAME)
+  uri: http://IP_ADDRESS:PORT

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -12,7 +12,7 @@ queue:
     database: 0
   prefix: ''
 
-unzip-worker:
+unzip-service:
   # https://github.com/taskrabbit/node-resque#multiworker-options
   # minimum number of workers to spawn
   minTaskProcessors: 1

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const boot = async () => {
     });
 
     multiWorker.start();
-}
+};
 
 boot();
 

--- a/index.js
+++ b/index.js
@@ -4,8 +4,10 @@ const NodeResque = require('node-resque');
 const config = require('config');
 const logger = require('screwdriver-logger');
 const jobs = require('./lib/jobs');
+const server = require('./lib/server');
 const { connectionDetails, queuePrefix } = require('./config/redis');
 const workerConfig = config.get('unzip-service');
+const httpdConfig = config.get('httpd');
 
 const multiWorker = new NodeResque.MultiWorker(
     {
@@ -19,47 +21,61 @@ const multiWorker = new NodeResque.MultiWorker(
     jobs
 );
 
-// normal worker emitters
-multiWorker.on('start', workerId => {
-    logger.info(`worker[${workerId}] started`);
-});
-multiWorker.on('end', workerId => {
-    logger.info(`worker[${workerId}] ended`);
-});
-multiWorker.on('cleaning_worker', (workerId, worker) => {
-    logger.info(`cleaning old worker[${workerId}] ${worker}`);
-});
-multiWorker.on('poll', (workerId, queue) => {
-    logger.info(`worker[${workerId}] polling ${queue}`);
-});
-multiWorker.on('ping', (workerId, time) => {
-    logger.info(`worker[${workerId}] check in @ ${time}`);
-});
-multiWorker.on('job', (workerId, queue, job) => {
-    logger.info(`worker[${workerId}] working job ${queue} ${JSON.stringify(job)}`);
-});
-multiWorker.on('reEnqueue', (workerId, queue, job, plugin) => {
-    logger.info(`worker[${workerId}] reEnqueue job (${JSON.stringify(plugin)}) ${queue} ${JSON.stringify(job)}`);
-});
-multiWorker.on('success', (workerId, queue, job, result) => {
-    logger.info(`worker[${workerId}] job success ${queue} ${JSON.stringify(job)} >> ${result}`);
-});
-multiWorker.on('failure', (workerId, queue, job, failure) => {
-    logger.info(`worker[${workerId}] job failure ${queue} ${JSON.stringify(job)} >> ${failure}`);
-});
-multiWorker.on('error', (workerId, queue, job, error) => {
-    logger.info(`worker[${workerId}] error ${queue} ${JSON.stringify(job)} >> ${error}`);
-});
-multiWorker.on('pause', workerId => {
-    logger.info(`worker[${workerId}] paused`);
-});
+const boot = async () => {
+    // Start http server for health check
+    await server.start(httpdConfig);
 
-// multiWorker emitters
-multiWorker.on('internalError', error => {
-    logger.error(error);
-});
-multiWorker.on('multiWorkerAction', (verb, delay) => {
-    logger.info(`*** checked for worker status: ${verb} (event loop delay: ${delay}ms)`);
-});
+    // normal worker emitters
+    multiWorker.on('start', workerId => {
+        logger.info(`worker[${workerId}] started`);
+    });
+    multiWorker.on('end', workerId => {
+        logger.info(`worker[${workerId}] ended`);
+    });
+    multiWorker.on('cleaning_worker', (workerId, worker) => {
+        logger.info(`cleaning old worker[${workerId}] ${worker}`);
+    });
+    multiWorker.on('poll', (workerId, queue) => {
+        logger.info(`worker[${workerId}] polling ${queue}`);
+    });
+    multiWorker.on('ping', (workerId, time) => {
+        logger.info(`worker[${workerId}] check in @ ${time}`);
+    });
+    multiWorker.on('job', (workerId, queue, job) => {
+        logger.info(`worker[${workerId}] working job ${queue} ${JSON.stringify(job)}`);
+    });
+    multiWorker.on('reEnqueue', (workerId, queue, job, plugin) => {
+        logger.info(`worker[${workerId}] reEnqueue job (${JSON.stringify(plugin)}) ${queue} ${JSON.stringify(job)}`);
+    });
+    multiWorker.on('success', (workerId, queue, job, result) => {
+        logger.info(`worker[${workerId}] job success ${queue} ${JSON.stringify(job)} >> ${result}`);
+    });
+    multiWorker.on('failure', (workerId, queue, job, failure) => {
+        logger.info(`worker[${workerId}] job failure ${queue} ${JSON.stringify(job)} >> ${failure}`);
+    });
+    multiWorker.on('error', (workerId, queue, job, error) => {
+        logger.info(`worker[${workerId}] error ${queue} ${JSON.stringify(job)} >> ${error}`);
+    });
+    multiWorker.on('pause', workerId => {
+        logger.info(`worker[${workerId}] paused`);
+    });
 
-multiWorker.start();
+    // multiWorker emitters
+    multiWorker.on('internalError', error => {
+        logger.error(error);
+    });
+    multiWorker.on('multiWorkerAction', (verb, delay) => {
+        // Save the last emitted time of this event for health check.
+        server.saveLastEmittedTime();
+        logger.info(`*** checked for worker status: ${verb} (event loop delay: ${delay}ms)`);
+    });
+
+    multiWorker.start();
+}
+
+boot();
+
+process.on('unhandledRejection', err => {
+    logger.error('Unhandled error', err);
+    process.exit(1);
+});

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const config = require('config');
 const logger = require('screwdriver-logger');
 const jobs = require('./lib/jobs');
 const { connectionDetails, queuePrefix } = require('./config/redis');
-const workerConfig = config.get('unzip-worker');
+const workerConfig = config.get('unzip-service');
 
 const multiWorker = new NodeResque.MultiWorker(
     {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const Hapi = require('@hapi/hapi');
+const logger = require('screwdriver-logger');
+
+let lastEmittedTime = null;
+
+const saveLastEmittedTime = () => {
+    const date = new Date();
+    lastEmittedTime = Math.floor(date.getTime() / 1000);
+}
+
+const start = async (config) => {
+    try {
+        const server = new Hapi.Server({
+            port: config.port,
+            host: config.host,
+            uri: config.uri,
+            routes: {
+                log: { collect: true }
+            },
+            router: {
+                stripTrailingSlash: true
+            }
+        });
+
+        server.route([
+            {
+                method: 'GET',
+                path: '/last-emitted',
+                config: {
+                    description: 'Last emitted time of the "multiWorkerAction" event.',
+                    notes: 'Should respond unixtime with 200',
+                    tags: ['api']
+                },
+                handler(request, h) {
+                    if (lastEmittedTime) {
+                        return h.response(lastEmittedTime).code(200);
+                    }
+
+                    return h.response('Can not get lastEmittedTime').code(503);
+                }
+            }
+        ]);
+
+        await server.start();
+        logger.info('Server running on %s', server.info.uri);
+
+        return server;
+    } catch (err) {
+        logger.error(`Error in starting server ${err}`);
+        throw err;
+    }
+};
+
+module.exports = {
+    start,
+    saveLastEmittedTime
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,10 +7,11 @@ let lastEmittedTime = null;
 
 const saveLastEmittedTime = () => {
     const date = new Date();
-    lastEmittedTime = Math.floor(date.getTime() / 1000);
-}
 
-const start = async (config) => {
+    lastEmittedTime = Math.floor(date.getTime() / 1000);
+};
+
+const start = async config => {
     try {
         const server = new Hapi.Server({
             port: config.port,
@@ -56,4 +57,4 @@ const start = async (config) => {
 module.exports = {
     start,
     saveLastEmittedTime
-}
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/screwdriver-cd/artifacts-unzip-service#readme",
   "contributors": [],
   "dependencies": {
+    "@hapi/hapi": "^20.2.1",
     "adm-zip": "^0.5.9",
     "config": "^3.3.6",
     "got": "^11.8.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "screwdriver-artifacts-unzip-worker",
+  "name": "screwdriver-artifacts-unzip-service",
   "version": "1.0.0",
   "description": "A resque worker implementation that unzips the ZIP artifacts.",
   "main": "index.js",
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/screwdriver-cd/artifacts-unzip-worker.git"
+    "url": "git+https://github.com/screwdriver-cd/artifacts-unzip-service.git"
   },
   "author": "Teppei Minegishi <saka2tetsu@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/screwdriver-cd/screwdriver/issues"
   },
-  "homepage": "https://github.com/screwdriver-cd/artifacts-unzip-worker#readme",
+  "homepage": "https://github.com/screwdriver-cd/artifacts-unzip-service#readme",
   "contributors": [],
   "dependencies": {
     "adm-zip": "^0.5.9",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,6 +1,6 @@
 shared:
   environment:
-    DOCKER_REPO: screwdrivercd/artifacts-unzip-worker
+    DOCKER_REPO: screwdrivercd/artifacts-unzip-service
 
 jobs:
   main:
@@ -39,10 +39,10 @@ jobs:
   #     - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
   #     - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
   #   environment:
-  #     K8S_CONTAINER: screwdriver-artifacts-unzip-worker
-  #     K8S_IMAGE: screwdrivercd/artifacts-unzip-worker
+  #     K8S_CONTAINER: screwdriver-artifacts-unzip-service
+  #     K8S_IMAGE: screwdrivercd/artifacts-unzip-service
   #     K8S_HOST: kubernetes.default.svc
-  #     K8S_DEPLOYMENT: sdartifacts-unzip-worker-beta
+  #     K8S_DEPLOYMENT: sdartifacts-unzip-service-beta
   #     K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX
   #     K8S_ENV_VALUE: beta_rc2_
   #   secrets:
@@ -58,10 +58,10 @@ jobs:
   #     - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
   #     - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
   #   environment:
-  #     K8S_CONTAINER: screwdriver-artifacts-unzip-worker
-  #     K8S_IMAGE: screwdrivercd/artifacts-unzip-worker
+  #     K8S_CONTAINER: screwdriver-artifacts-unzip-service
+  #     K8S_IMAGE: screwdrivercd/artifacts-unzip-service
   #     K8S_HOST: kubernetes.default.svc
-  #     K8S_DEPLOYMENT: sdartifacts-unzip-worker
+  #     K8S_DEPLOYMENT: sdartifacts-unzip-service
   #     K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX
   #     K8S_ENV_VALUE: rc2_
   #   secrets:

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('assert');
+const server = require('../../lib/server');
+
+const serverConfig = {
+    port: 80,
+    host: '0.0.0.0'
+};
+
+describe('GET /last-emitted', () => {
+    let serverInstance;
+    const requestParam = {
+        method: 'get',
+        url: '/last-emitted'
+    };
+
+    afterEach(async () => {
+        await serverInstance.stop();
+    });
+
+    it('responds with 503', async () => {
+        serverInstance = await server.start(serverConfig);
+        const res = await serverInstance.inject(requestParam);
+
+        assert.equal(res.result, 'Can not get lastEmittedTime');
+        assert.equal(res.statusCode, 503);
+    });
+
+    it('responds with 200', async () => {
+        serverInstance = await server.start(serverConfig);
+        server.saveLastEmittedTime();
+        const res = await serverInstance.inject(requestParam);
+
+        assert.equal(res.statusCode, 200);
+    });
+});


### PR DESCRIPTION
## Context
1. There is no way to check whether MultiWorker instance of node-resque is working or not.
2. The name `unzip-worker` makes confusion whether it is part of build-worker.  

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
1. Add health-check endpoint. The endpoint returns a last emitted time of MultiWorker event that emits periodically.
2. Rename `unzip-worker` to `unzip-service`.  

<!-- What does this PR fix? What intentional changes will this PR make? -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
