### PR TITLE
fix: down grade node-resque version

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const logger = require('screwdriver-logger');
-const plugins = require('node-resque').Plugins;
 const AdmZip = require('adm-zip');
 
 const store = require('./helper/request-store');
@@ -55,7 +54,7 @@ async function unzip(config) {
 
 module.exports = {
     start: {
-        plugins: [plugins.Retry],
+        plugins: ['Retry'],
         pluginOptions: {
             Retry: retryOptions
         },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "config": "^3.3.6",
     "got": "^11.8.3",
     "js-yaml": "^4.1.0",
-    "node-resque": "^9.1.2",
+    "node-resque": "^5.5.3",
     "screwdriver-logger": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Context
Latest version of node-resque does not work on our production environment.
Reason is not clear yet, but older one which is using in queue-service 'dose' work, so we will use this version for while.
Later, we will fix our environment working with latest node-resque version with [this issue](https://github.com/screwdriver-cd/screwdriver/issues/2667).

## Objective
Fix node-resque version as same as [queue-service](https://github.com/screwdriver-cd/queue-service/blob/5d51f47665717785d40639234baaa02cd5fbd7d0/package.json#L28).  


## References
- [queue-service](https://github.com/screwdriver-cd/queue-service/blob/5d51f47665717785d40639234baaa02cd5fbd7d0/package.json#L28)
- [issue](https://github.com/screwdriver-cd/screwdriver/issues/2667)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
