### PR TITLE
fix: Added the function to limit the number of parallel uploads

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -24,6 +24,8 @@ unzip-service:
   checkTimeout: WORKER_CHECK_TIMEOUT
   # how long the event loop has to be delayed before considering it blocked (ms)
   maxEventLoopDelay: WORKER_MAX_EVENT_LOOP_DELAY
+  # number of parallel executions for asynchronous upload of unzipped files to store
+  parallelUploadLimit: WORKER_PARALLEL_UPLOAD_LIMIT
 
 httpd:
   # Port to listen on

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -22,6 +22,9 @@ unzip-service:
   checkTimeout: 1000
   # how long the event loop has to be delayed before considering it blocked (ms)
   maxEventLoopDelay: 10
+  # number of parallel executions for asynchronous upload of unzipped files to store
+  # if set to 0, unlimited.
+  parallelUploadLimit: 0
 
 httpd:
   # Port to listen on

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -2,12 +2,13 @@
 
 const logger = require('screwdriver-logger');
 const AdmZip = require('adm-zip');
-
+const unzipService = require('config').get('unzip-service');
 const store = require('./helper/request-store');
 
 const RETRY_LIMIT = 3;
 // This is in milliseconds, reference: https://github.com/actionhero/node-resque/blob/fe89056671af32e35695332b248c1df1e422431e/src/plugins/Retry.ts#L23
 const RETRY_DELAY = 5 * 1000;
+const PARALLEL_UPLOAD_LIMIT = unzipService.parallelUploadLimit;
 
 const retryOptions = {
     retryLimit: RETRY_LIMIT,
@@ -30,14 +31,21 @@ async function unzip(config) {
         const zipBuffer = new AdmZip(zipFile.body);
         const zipEntries = zipBuffer.getEntries();
 
-        await Promise.all(
-            zipEntries.map(async zipEntry => {
-                const fileName = zipEntry.entryName;
-                const file = Buffer.from(zipEntry.getData());
+        const uploadFiles = zipEntries.map(async zipEntry => {
+            const fileName = zipEntry.entryName;
+            const file = Buffer.from(zipEntry.getData());
 
-                return store.putArtifact(config.buildId, config.token, fileName, file);
-            })
-        );
+            return store.putArtifact(config.buildId, config.token, fileName, file);
+        });
+
+        if (PARALLEL_UPLOAD_LIMIT <= 0) {
+            await Promise.all(uploadFiles);
+        } else {
+            while (uploadFiles.length > 0) {
+                // eslint-disable-next-line no-await-in-loop
+                await Promise.all(uploadFiles.splice(0, PARALLEL_UPLOAD_LIMIT));
+            }
+        }
     } catch (err) {
         logger.error(err.message);
         throw err;


### PR DESCRIPTION
## Context
There was no limit on the number of parallels for unzipping files and uploading them to the Store. 
This caused a problem when a large number of files came to the `artifact-unzip-service`, which occupied CPU and made it impossible to respond to kubernetes probe.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Fixed so that the number of parallels can be set.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
