### PR TITLE
fix: position of unzip and store push

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -22,6 +22,21 @@ const retryOptions = {
 logger.info(`The setting value of PARALLEL_UPLOAD_LIMIT is ${PARALLEL_UPLOAD_LIMIT}`);
 
 /**
+ * Extract data from the zip file and upload to store.
+ * @method _uploadToStore
+ * @param buildId {Integer} The ID of build that owned the artifacts
+ * @param token {String} The token to upload the extracted artifacts
+ * @param zipEntry
+ * @returns {Promise}
+ */
+async function _uploadToStore(buildId, token, zipEntry) {
+    const fileName = zipEntry.entryName;
+    const file = Buffer.from(zipEntry.getData());
+
+    return store.putArtifact(buildId, token, fileName, file);
+}
+
+/**
  * Unzip ZIP artifacts and re-uploads the extracted artifacts to Store
  * @method unzip
  * @param  {Object}   config           Configuration object
@@ -38,24 +53,14 @@ async function unzip(config) {
         const zipEntries = zipBuffer.getEntries();
 
         if (PARALLEL_UPLOAD_LIMIT <= 0) {
-            await Promise.all(
-                zipEntries.map(async zipEntry => {
-                    const fileName = zipEntry.entryName;
-                    const file = Buffer.from(zipEntry.getData());
-
-                    return store.putArtifact(config.buildId, config.token, fileName, file);
-                })
-            );
+            await Promise.all(zipEntries.map(zipEntry => _uploadToStore(config.buildId, config.token, zipEntry)));
         } else {
             while (zipEntries.length > 0) {
                 // eslint-disable-next-line no-await-in-loop
                 await Promise.all(
-                    zipEntries.splice(0, PARALLEL_UPLOAD_LIMIT).map(async zipEntry => {
-                        const fileName = zipEntry.entryName;
-                        const file = Buffer.from(zipEntry.getData());
-
-                        return store.putArtifact(config.buildId, config.token, fileName, file);
-                    })
+                    zipEntries
+                        .splice(0, PARALLEL_UPLOAD_LIMIT)
+                        .map(zipEntry => _uploadToStore(config.buildId, config.token, zipEntry))
                 );
             }
         }

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -19,6 +19,8 @@ const retryOptions = {
     retryDelay: RETRY_DELAY
 };
 
+logger.info(`The setting value of PARALLEL_UPLOAD_LIMIT is ${PARALLEL_UPLOAD_LIMIT}`);
+
 /**
  * Unzip ZIP artifacts and re-uploads the extracted artifacts to Store
  * @method unzip
@@ -35,19 +37,26 @@ async function unzip(config) {
         const zipBuffer = new AdmZip(zipFile.body);
         const zipEntries = zipBuffer.getEntries();
 
-        const uploadFiles = zipEntries.map(async zipEntry => {
-            const fileName = zipEntry.entryName;
-            const file = Buffer.from(zipEntry.getData());
-
-            return store.putArtifact(config.buildId, config.token, fileName, file);
-        });
-
         if (PARALLEL_UPLOAD_LIMIT <= 0) {
-            await Promise.all(uploadFiles);
+            await Promise.all(
+                zipEntries.map(async zipEntry => {
+                    const fileName = zipEntry.entryName;
+                    const file = Buffer.from(zipEntry.getData());
+
+                    return store.putArtifact(config.buildId, config.token, fileName, file);
+                })
+            );
         } else {
-            while (uploadFiles.length > 0) {
+            while (zipEntries.length > 0) {
                 // eslint-disable-next-line no-await-in-loop
-                await Promise.all(uploadFiles.splice(0, PARALLEL_UPLOAD_LIMIT));
+                await Promise.all(
+                    zipEntries.splice(0, PARALLEL_UPLOAD_LIMIT).map(async zipEntry => {
+                        const fileName = zipEntry.entryName;
+                        const file = Buffer.from(zipEntry.getData());
+
+                        return store.putArtifact(config.buildId, config.token, fileName, file);
+                    })
+                );
             }
         }
     } catch (err) {


### PR DESCRIPTION
## Context
Fix unzip and push to store were not working in parallel correctly in #7.

Problem with #7 code.
The `await` only waits for the parallel execution to "complete," and the execution is done in the order of the code.
Therefore, in #7, the contents of `_uploadToStore`, which should have been executed in parallel, were executed at the stage of assigning them to variables.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
