### PR TITLE
feat: [2] update node-resque and support redis cluster connection

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -5,6 +5,8 @@ ecosystem:
   store: ECOSYSTEM_STORE
 
 queue:
+  # redis or redisCluster(beta)
+  connectionType: REDIS_TYPE
   redisConnection:
     host: REDIS_HOST
     port: REDIS_PORT
@@ -12,6 +14,14 @@ queue:
       password: REDIS_PASSWORD
       tls: REDIS_TLS_ENABLED
     database: REDIS_DB_NUMBER
+  redisClusterConnection:
+    hosts:
+      __name: REDIS_CLUSTER_HOSTS
+      __format: json
+    options:
+      password: REDIS_PASSWORD
+      tls: REDIS_TLS_ENABLED
+    slotsRefreshTimeout: REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT
   prefix: REDIS_QUEUE_PREFIX
 
 unzip-service:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,6 +3,8 @@ ecosystem:
   store: http://IP_ADDRESS:PORT
 
 queue:
+  # redis or redisCluster(beta)
+  connectionType: redis
   redisConnection:
     host: REDIS_HOST
     port: REDIS_PORT
@@ -10,7 +12,13 @@ queue:
       password: a-secure-password
       tls: false
     database: 0
-  prefix: ''
+  redisClusterConnection:
+    hosts: []
+    options:
+      password: a-secure-password
+      tls: false
+    slotsRefreshTimeout: 1000
+  prefix: ""
 
 unzip-service:
   # https://github.com/taskrabbit/node-resque#multiworker-options

--- a/config/redis.js
+++ b/config/redis.js
@@ -5,9 +5,9 @@ const config = require('config');
 const queueConfig = config.get('queue');
 const connectionType = queueConfig.connectionType;
 
-if (!connectionType && (connectionType !== 'redis' || connectionType !== 'redisCluster')) {
+if (!connectionType || (connectionType !== 'redis' || connectionType !== 'redisCluster')) {
     throw new Error(
-        `'${connectionType}' is not supported in connectionType, 'redis' or 'redisCluster' can be set for the queue.connectionType setting`
+        `connectionType '${connectionType}' is not supported, use 'redis' or 'redisCluster' for the queue.connectionType setting`
     );
 }
 

--- a/config/redis.js
+++ b/config/redis.js
@@ -5,7 +5,7 @@ const config = require('config');
 const queueConfig = config.get('queue');
 const connectionType = queueConfig.connectionType;
 
-if (!connectionType || (connectionType !== 'redis' || connectionType !== 'redisCluster')) {
+if (!connectionType || (connectionType !== 'redis' && connectionType !== 'redisCluster')) {
     throw new Error(
         `connectionType '${connectionType}' is not supported, use 'redis' or 'redisCluster' for the queue.connectionType setting`
     );

--- a/config/redis.js
+++ b/config/redis.js
@@ -3,20 +3,44 @@
 const config = require('config');
 
 const queueConfig = config.get('queue');
-const redisConfig = queueConfig.redisConnection;
+const connectionType = queueConfig.connectionType;
+
+if (!connectionType && (connectionType !== 'redis' || connectionType !== 'redisCluster')) {
+    throw new Error(
+        `'${connectionType}' is not supported in connectionType, 'redis' or 'redisCluster' can be set for the queue.connectionType setting`
+    );
+}
+
+const redisConfig = queueConfig[`${connectionType}Connection`];
 const connectionDetails = {
-    pkg: 'ioredis',
-    host: redisConfig.host,
-    options: {
+    redisOptions: {
         password: redisConfig.options && redisConfig.options.password,
         tls: redisConfig.options ? redisConfig.options.tls : false
-    },
-    port: redisConfig.port,
-    database: redisConfig.database
+    }
 };
+
+let queueNamespace;
+
+// for redisCluster config
+if (connectionType === 'redisCluster') {
+    connectionDetails.redisClusterHosts = redisConfig.hosts;
+    connectionDetails.slotsRefreshTimeout = redisConfig.slotsRefreshTimeout;
+    // NOTE: node-resque has an issue  in multi-key operation for Redis Cluster
+    // https://github.com/actionhero/node-resque/issues/786
+    // so we have to set the namespace option with a hash tag so that the resque's keys are set in the same slots in Redis Cluster
+    // https://redis.io/docs/manual/scaling/#redis-cluster-data-sharding
+    queueNamespace = 'resque:{screwdriver-resque}';
+} else {
+    // for non-cluster redis config
+    connectionDetails.redisOptions.host = redisConfig.host;
+    connectionDetails.redisOptions.port = redisConfig.port;
+    connectionDetails.redisOptions.database = redisConfig.database;
+    queueNamespace = 'resque';
+}
 const queuePrefix = queueConfig.prefix || '';
 
 module.exports = {
     connectionDetails,
+    queueNamespace,
     queuePrefix
 };

--- a/index.js
+++ b/index.js
@@ -62,11 +62,11 @@ const boot = async () => {
     multiWorker.on('reEnqueue', (workerId, queue, job, plugin) => {
         logger.info(`worker[${workerId}] reEnqueue job (${JSON.stringify(plugin)}) ${queue} ${JSON.stringify(job)}`);
     });
-    multiWorker.on('success', (workerId, queue, job, result) => {
-        logger.info(`worker[${workerId}] job success ${queue} ${JSON.stringify(job)} >> ${result}`);
+    multiWorker.on('success', (workerId, queue, job, result, duration) => {
+        logger.info(`worker[${workerId}] job success ${queue} ${JSON.stringify(job)} >> ${result} (${duration}ms)`);
     });
-    multiWorker.on('failure', (workerId, queue, job, failure) => {
-        logger.info(`worker[${workerId}] job failure ${queue} ${JSON.stringify(job)} >> ${failure}`);
+    multiWorker.on('failure', (workerId, queue, job, failure, duration) => {
+        logger.info(`worker[${workerId}] job failure ${queue} ${JSON.stringify(job)} >> ${failure} (${duration}ms)`);
     });
     multiWorker.on('error', (workerId, queue, job, error) => {
         logger.info(`worker[${workerId}] error ${queue} ${JSON.stringify(job)} >> ${error}`);
@@ -76,9 +76,6 @@ const boot = async () => {
     });
 
     // multiWorker emitters
-    multiWorker.on('internalError', error => {
-        logger.error(error);
-    });
     multiWorker.on('multiWorkerAction', (verb, delay) => {
         // Save the last emitted time of this event for health check.
         server.saveLastEmittedTime();

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -2,6 +2,7 @@
 
 const logger = require('screwdriver-logger');
 const AdmZip = require('adm-zip');
+const { Plugins } = require('node-resque');
 const unzipService = require('config').get('unzip-service');
 const store = require('./helper/request-store');
 
@@ -80,7 +81,7 @@ async function unzip(config) {
 
 module.exports = {
     start: {
-        plugins: ['Retry'],
+        plugins: [Plugins.Retry],
         pluginOptions: {
             Retry: retryOptions
         },

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "adm-zip": "^0.5.9",
     "config": "^3.3.6",
     "got": "^11.8.3",
+    "ioredis": "^5.2.3",
     "js-yaml": "^4.1.0",
-    "node-resque": "^5.5.3",
+    "node-resque": "^9.2.0",
     "screwdriver-logger": "^1.1.0"
   },
   "devDependencies": {

--- a/test/config/redis.test.js
+++ b/test/config/redis.test.js
@@ -104,4 +104,18 @@ describe('redis config', () => {
             assert.exists(err, "'redis' or 'redisCluster' can be set for queue.connectionType");
         }
     });
+
+    it('throws exception if connectionType is not specified', async () => {
+        const testQueueConfig = Object.assign({}, queueConfig);
+
+        testQueueConfig.connectionType = '';
+        configMock.get.returns(testQueueConfig);
+
+        try {
+            /* eslint-disable global-require */
+            require('../../config/redis');
+        } catch (err) {
+            assert.exists(err, "'redis' or 'redisCluster' can be set for queue.connectionType");
+        }
+    });
 });

--- a/test/config/redis.test.js
+++ b/test/config/redis.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { assert } = require('chai');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('redis config', () => {
+    const queueConfig = {
+        connectionType: 'redis',
+        redisConnection: {
+            port: 4321,
+            host: '127.0.0.0',
+            options: {
+                tls: true,
+                password: 'abcd'
+            },
+            database: 0
+        },
+        redisClusterConnection: {
+            hosts: ['127.0.0.0:4321', '127.0.0.0:4322', '127.0.0.0:4323'],
+            options: {
+                tls: true,
+                password: 'abcd'
+            },
+            slotsRefreshTimeout: 1000
+        },
+        prefix: 'test'
+    };
+    const configMock = {
+        get: sinon.stub()
+    };
+
+    before(() => {
+        mockery.enable({
+            warnOnUnregistered: false,
+            useCleanCache: true
+        });
+    });
+
+    beforeEach(() => {
+        mockery.registerMock('config', configMock);
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('gets config for a redis connection', async () => {
+        const testQueueConfig = Object.assign({}, queueConfig);
+
+        configMock.get.returns(testQueueConfig);
+
+        /* eslint-disable global-require */
+        const redisConfig = require('../../config/redis');
+
+        assert.deepEqual(redisConfig.connectionDetails.redisOptions, {
+            port: 4321,
+            host: '127.0.0.0',
+            tls: true,
+            password: 'abcd',
+            database: 0
+        });
+        assert.equal(redisConfig.queueNamespace, 'resque');
+        assert.equal(redisConfig.queuePrefix, 'test');
+    });
+
+    it('gets config for redisCluster connection', async () => {
+        const testQueueConfig = Object.assign({}, queueConfig);
+
+        testQueueConfig.connectionType = 'redisCluster';
+        configMock.get.returns(testQueueConfig);
+
+        /* eslint-disable global-require */
+        const redisConfig = require('../../config/redis');
+
+        assert.deepEqual(redisConfig.connectionDetails.redisOptions, {
+            tls: true,
+            password: 'abcd'
+        });
+        assert.equal(redisConfig.connectionDetails.redisClusterHosts[0], '127.0.0.0:4321');
+        assert.equal(redisConfig.connectionDetails.redisClusterHosts[1], '127.0.0.0:4322');
+        assert.equal(redisConfig.connectionDetails.redisClusterHosts[2], '127.0.0.0:4323');
+        assert.equal(redisConfig.queueNamespace, 'resque:{screwdriver-resque}');
+        assert.equal(redisConfig.queuePrefix, 'test');
+    });
+
+    it('throws exception if unkown connectionType is specified', async () => {
+        const testQueueConfig = Object.assign({}, queueConfig);
+
+        testQueueConfig.connectionType = 'mysql';
+        configMock.get.returns(testQueueConfig);
+
+        try {
+            /* eslint-disable global-require */
+            require('../../config/redis');
+        } catch (err) {
+            assert.exists(err, "'redis' or 'redisCluster' can be set for queue.connectionType");
+        }
+    });
+});


### PR DESCRIPTION
## Context
To support Redis Cluster integration

node-resque says it supports Redis Cluster since 7.1.0
https://github.com/actionhero/node-resque/releases/tag/v7.1.0

## Objective
This PR updates node-resque to support Redis Cluster instead of single Redis.
For more information on this change, see also the PR description below.
https://github.com/screwdriver-cd/queue-service/pull/57

## References
https://github.com/screwdriver-cd/screwdriver/issues/2667

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
