### PR TITLE
fix: unzip-service can't start when WORKER_MAX_TASK_PROCESSORS is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@ const multiWorker = new NodeResque.MultiWorker(
     {
         connection: { redis, namespace: queueNamespace },
         queues: [`${queuePrefix}unzip`],
-        minTaskProcessors: workerConfig.minTaskProcessors,
-        maxTaskProcessors: workerConfig.maxTaskProcessors,
-        checkTimeout: workerConfig.checkTimeout,
-        maxEventLoopDelay: workerConfig.maxEventLoopDelay
+        minTaskProcessors: parseInt(workerConfig.minTaskProcessors, 10),
+        maxTaskProcessors: parseInt(workerConfig.maxTaskProcessors, 10),
+        checkTimeout: parseInt(workerConfig.checkTimeout, 10),
+        maxEventLoopDelay: parseInt(workerConfig.maxEventLoopDelay, 10)
     },
     jobs
 );


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
same fix of https://github.com/screwdriver-cd/queue-service/pull/59

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
