### PR TITLE
fix: Manually bump the patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-artifacts-unzip-service",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A resque worker implementation that unzips the ZIP artifacts.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-artifacts-unzip-service",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A resque worker implementation that unzips the ZIP artifacts.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Context
[Empty commit doesn't work](https://github.com/screwdriver-cd/artifacts-unzip-service/pull/15) because the previous failed build already pushed an NPM version out and the `npm-auto-version` library doesn't play nice because there wasn't a git tag already pushed.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
