### PR TITLE
fix: Manually bump the patch version to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-artifacts-unzip-service",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A resque worker implementation that unzips the ZIP artifacts.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Context

Manually bump the patch version to 2.2.0 to run the build. 
 
## Objective

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
