### PR TITLE
feat: add GIT_KEY_BASE64 for publish step

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -25,7 +25,7 @@ jobs:
       # Publishing to NPM
       - NPM_TOKEN
       # Pushing tags to Git
-      - GIT_KEY
+      - GIT_KEY_BASE64
 
   docker-publish:
     requires: publish


### PR DESCRIPTION
## Context

The previous GIT_KEY secret is obsoleted. And the [build](https://cd.screwdriver.cd/pipelines/8204/builds/971603/steps/publish-npm-and-git-tag) failed as the result.

## Objective

Replaced GIT_KEY with GIT_KEY_BASE64. 

## References


## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
